### PR TITLE
Correct docker versioning 

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,26 +124,26 @@ Publication - https://ai.google/research/pubs/pub46977
 
     Uncommenting line 37
 
-    ```
+    ```sh
     gcloud docker --project="${PROJECT_ID}" -- push "$IMAGE"
     ```
 
     And commenting out line 45
 
-    ```
-    #docker -- push gcr.io/blackfoot-revitalization/ui:latest
+    ```sh
+    # docker -- push gcr.io/blackfoot-revitalization/ui:latest
     ```
 
     This will run the Docker push directly through `gcloud`
 
     Now run:
 
-    ```
+    ```sh
     ./deploy.sh ui create
     ```
     After the deployment, you should get an IP that you can access from command
-    line's result (EXTERNAL_IP). You can access your instance of Voice Builder
-    by visiting http://EXTERNAL_IP:3389 in
+    line's result `EXTERNAL_IP`. You can access your instance of Voice Builder
+    by visiting `http://EXTERNAL_IP:3389` in
     your browser.
 
 ### Create an example voice

--- a/README.md
+++ b/README.md
@@ -105,6 +105,40 @@ Publication - https://ai.google/research/pubs/pub46977
 
 4. Deploy ui component
 
+    ### *Note on Docker versioning*
+
+    This script has been edited for use with Docker versions more recent than
+    18.03
+
+    Before running ui deployment please run
+
+    ```
+    gcloud auth configure-docker
+    ```
+
+    to configure `docker` to use `gcloud` as a credential helper
+
+    If you are running the deprecated versioning of Docker (`18.03` or lower),
+    you may skip this step and instead edit
+
+    `build_docker.sh`
+
+    Uncommenting line 37
+
+    ```
+    gcloud docker --project="${PROJECT_ID}" -- push "$IMAGE"
+    ```
+
+    and commenting out line 45
+
+    ```
+    #docker -- push gcr.io/blackfoot-revitalization/ui:latest
+    ```
+
+    to edit the code to run the Docker push directly through `gcloud`
+
+    Now run:
+
     ```
     ./deploy.sh ui create
     ```

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Publication - https://ai.google/research/pubs/pub46977
     gcloud auth configure-docker
     ```
 
-    to configure `docker` to use `gcloud` as a credential helper
+    This will configure `docker` to use `gcloud` as a credential helper
 
     ### Docker version <=  18.03
 
@@ -128,13 +128,13 @@ Publication - https://ai.google/research/pubs/pub46977
     gcloud docker --project="${PROJECT_ID}" -- push "$IMAGE"
     ```
 
-    and commenting out line 45
+    And commenting out line 45
 
     ```
     #docker -- push gcr.io/blackfoot-revitalization/ui:latest
     ```
 
-    to edit the code to run the Docker push directly through `gcloud`
+    This will run the Docker push directly through `gcloud`
 
     Now run:
 

--- a/README.md
+++ b/README.md
@@ -105,10 +105,7 @@ Publication - https://ai.google/research/pubs/pub46977
 
 4. Deploy ui component
 
-    ### *Note on Docker versioning*
-
-    This script has been edited for use with Docker versions more recent than
-    18.03
+    ### Docker version > 18.03
 
     Before running ui deployment please run
 
@@ -118,8 +115,10 @@ Publication - https://ai.google/research/pubs/pub46977
 
     to configure `docker` to use `gcloud` as a credential helper
 
+    ### Docker version <=  18.03
+
     If you are running the deprecated versioning of Docker (`18.03` or lower),
-    you may skip this step and instead edit
+    edit
 
     `build_docker.sh`
 

--- a/build_docker.sh
+++ b/build_docker.sh
@@ -24,7 +24,7 @@ fi
 IMAGE=$1
 DIR=$2
 PROJECT_ID=$3
-DOCKER_CMD="docker build --no-cache -t $IMAGE $DIR"
+DOCKER_CMD="sudo docker build --no-cache -t $IMAGE $DIR"
 TIMESTAMP=$(date +%s)
 echo "timestamp: $TIMESTAMP"
 
@@ -32,4 +32,14 @@ echo "timestamp: $TIMESTAMP"
 echo "running: $DOCKER_CMD"
 eval "${DOCKER_CMD}"
 
-gcloud docker --project="${PROJECT_ID}" -- push "$IMAGE"
+#This command requires docker version 18.03 or below:
+
+#gcloud docker --project="${PROJECT_ID}" -- push "$IMAGE"
+
+#This docker usage is deprecated
+#run `gcloud auth configure-docker` to configure `docker` to use `gcloud` as a
+#credential helper
+
+#then run:
+
+docker -- push gcr.io/blackfoot-revitalization/ui:latest

--- a/deploy.sh
+++ b/deploy.sh
@@ -13,10 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-PROJECT_NAME="<PROJECT_NAME>"
+PROJECT_NAME="rosie-blackfoot-revitalization"
 PROJECT_NAME_LOWERCASE="${PROJECT_NAME,,}"
-PROJECT_ID="<PROJECT_ID>"
-GCP_SERVICE_ACCOUNT_EMAIL="<GCP_SERVICE_ACCOUNT_EMAIL>"
+PROJECT_ID="blackfoot-revitalization"
+GCP_SERVICE_ACCOUNT_EMAIL=" 819767746658-compute@developer.gserviceaccount.com"
 DATA_EXPORTER_SERVICE_ACCOUNT="<DATA_EXPORTER_SERVICE_ACCOUNT>"
 
 CONTAINER_REGISTRY="gcr.io/${PROJECT_ID}"


### PR DESCRIPTION
Google Cloud does natively support Docker versions above 18.03. The code has been corrected to allow for newer docker versions, with the ability to revert if using an older version of Docker. The README has been updated to explain this implementation.